### PR TITLE
Add core domain scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Comprehensive documentation is available in the [`docs/`](docs/) directory:
    php artisan serve
    ```
 
+### Demo Accounts
+- Admin: admin@example.com / password
+- Client: client@example.com / password
+
+### Configuration
+Dictionary and settings are defined in `config/nautica.php`.
+
 ---
 
 ## 🎯 Core Concepts

--- a/app/Console/Commands/ExpireBookingHolds.php
+++ b/app/Console/Commands/ExpireBookingHolds.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Booking;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class ExpireBookingHolds extends Command
+{
+    protected $signature = 'bookings:expire-holds';
+
+    protected $description = 'Release expired booking holds';
+
+    public function handle(): int
+    {
+        $count = Booking::where('status', 'on_hold')
+            ->whereNotNull('hold_expires_at')
+            ->where('hold_expires_at', '<', Carbon::now())
+            ->update(['status' => 'requested', 'hold_expires_at' => null]);
+
+        $this->info("Released {$count} booking holds.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('bookings:expire-holds')->hourly();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\User;
+use App\Support\Dictionary;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Booking extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'client_id','vessel_id','property_id','resource_id','slot_id',
+        'start_at','end_at','status','type','priority','hold_expires_at',
+        'notes','admin_notes'
+    ];
+
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+        'hold_expires_at' => 'datetime',
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(User::class, 'client_id');
+    }
+
+    public function vessel()
+    {
+        return $this->belongsTo(Vessel::class);
+    }
+
+    public function property()
+    {
+        return $this->belongsTo(Property::class);
+    }
+
+    public function resource()
+    {
+        return $this->belongsTo(Resource::class);
+    }
+
+    public function slot()
+    {
+        return $this->belongsTo(Slot::class);
+    }
+
+    public function logs()
+    {
+        return $this->hasMany(BookingLog::class);
+    }
+
+    public function setStatusAttribute($value)
+    {
+        if (!Dictionary::isValid('booking_statuses', $value)) {
+            throw new \InvalidArgumentException('Invalid booking status');
+        }
+        $this->attributes['status'] = $value;
+    }
+}

--- a/app/Models/BookingLog.php
+++ b/app/Models/BookingLog.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class BookingLog extends Model
+{
+    use HasFactory;
+
+    public $timestamps = false;
+
+    protected $fillable = ['booking_id','status','notes','created_at'];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function booking()
+    {
+        return $this->belongsTo(Booking::class);
+    }
+}

--- a/app/Models/Contract.php
+++ b/app/Models/Contract.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Contract extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['booking_id','status','effective_from','effective_to','terms_json','total'];
+
+    protected $casts = [
+        'effective_from' => 'date',
+        'effective_to' => 'date',
+        'terms_json' => 'array',
+    ];
+
+    public function booking()
+    {
+        return $this->belongsTo(Booking::class);
+    }
+
+    public function invoices()
+    {
+        return $this->hasMany(Invoice::class);
+    }
+}

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Invoice extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['contract_id','booking_id','invoice_no','status','currency','total','issued_at','due_at'];
+
+    protected $casts = [
+        'issued_at' => 'datetime',
+        'due_at' => 'datetime',
+    ];
+
+    public function contract()
+    {
+        return $this->belongsTo(Contract::class);
+    }
+
+    public function booking()
+    {
+        return $this->belongsTo(Booking::class);
+    }
+
+    public function lines()
+    {
+        return $this->hasMany(InvoiceLine::class);
+    }
+
+    public function payments()
+    {
+        return $this->hasMany(Payment::class);
+    }
+}

--- a/app/Models/InvoiceLine.php
+++ b/app/Models/InvoiceLine.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class InvoiceLine extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['invoice_id','description','qty','unit_price','tax_rate','amount'];
+
+    public function invoice()
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+}

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['invoice_id','method','amount','paid_at','reference'];
+
+    protected $casts = [
+        'paid_at' => 'datetime',
+    ];
+
+    public function invoice()
+    {
+        return $this->belongsTo(Invoice::class);
+    }
+}

--- a/app/Models/Property.php
+++ b/app/Models/Property.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Property extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'code', 'address'];
+
+    public function resources()
+    {
+        return $this->hasMany(Resource::class);
+    }
+}

--- a/app/Models/Resource.php
+++ b/app/Models/Resource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Resource extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['property_id', 'name', 'capacity', 'attributes'];
+
+    protected $casts = [
+        'attributes' => 'array',
+    ];
+
+    public function property()
+    {
+        return $this->belongsTo(Property::class);
+    }
+
+    public function slots()
+    {
+        return $this->hasMany(Slot::class);
+    }
+}

--- a/app/Models/Slot.php
+++ b/app/Models/Slot.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Slot extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['resource_id', 'start_at', 'end_at', 'is_available'];
+
+    protected $casts = [
+        'start_at' => 'datetime',
+        'end_at' => 'datetime',
+        'is_available' => 'boolean',
+    ];
+
+    public function resource()
+    {
+        return $this->belongsTo(Resource::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Spatie\Permission\Traits\HasRoles;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
@@ -10,7 +11,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable;
+    use HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/Vessel.php
+++ b/app/Models/Vessel.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Vessel extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['client_id', 'name', 'length', 'width', 'attributes'];
+
+    protected $casts = [
+        'attributes' => 'array',
+    ];
+
+    public function client()
+    {
+        return $this->belongsTo(User::class, 'client_id');
+    }
+
+    public function bookings()
+    {
+        return $this->hasMany(Booking::class);
+    }
+}

--- a/app/Support/Dictionary.php
+++ b/app/Support/Dictionary.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Support;
+
+class Dictionary
+{
+    public static function options(string $key): array
+    {
+        return config("nautica.dictionaries.$key", []);
+    }
+
+    public static function label(string $key, string $value, ?string $default = null): ?string
+    {
+        return self::options($key)[$value] ?? $default;
+    }
+
+    public static function keys(string $key): array
+    {
+        return array_keys(self::options($key));
+    }
+
+    public static function isValid(string $key, string $value): bool
+    {
+        return in_array($value, self::keys($key), true);
+    }
+}

--- a/config/nautica.php
+++ b/config/nautica.php
@@ -1,0 +1,60 @@
+<?php
+
+return [
+    'settings' => [
+        'booking' => [
+            'hold_minutes' => env('BOOKING_HOLD_MINUTES', 120),
+            'require_approval' => env('BOOKING_REQUIRE_APPROVAL', true),
+        ],
+    ],
+
+    'dictionaries' => [
+        'booking_statuses' => [
+            'requested' => 'Requested',
+            'on_hold' => 'On Hold',
+            'approved' => 'Approved',
+            'rejected' => 'Rejected',
+            'cancelled' => 'Cancelled',
+        ],
+        'booking_types' => [
+            'standard' => 'Standard',
+            'emergency' => 'Emergency',
+        ],
+        'priority_levels' => [
+            'normal' => 'Normal',
+            'high' => 'High',
+        ],
+        'contract_statuses' => [
+            'draft' => 'Draft',
+            'active' => 'Active',
+            'terminated' => 'Terminated',
+        ],
+        'invoice_statuses' => [
+            'draft' => 'Draft',
+            'sent' => 'Sent',
+            'paid' => 'Paid',
+            'void' => 'Void',
+        ],
+        'payment_methods' => [
+            'bank_transfer' => 'Bank Transfer',
+            'card' => 'Card',
+            'cash' => 'Cash',
+        ],
+    ],
+
+    'schedule' => [
+        'views' => [
+            'daily' => 'Daily',
+            'weekly' => 'Weekly',
+        ],
+    ],
+
+    'reports' => [
+        'enabled' => [
+            'bookings' => true,
+            'revenue' => true,
+            'utilization' => true,
+        ],
+    ],
+];
+

--- a/database/migrations/2025_08_18_130000_create_properties_table.php
+++ b/database/migrations/2025_08_18_130000_create_properties_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('properties', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('code')->unique();
+            $table->string('address')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('properties');
+    }
+};

--- a/database/migrations/2025_08_18_130100_create_resources_table.php
+++ b/database/migrations/2025_08_18_130100_create_resources_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('resources', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->unsignedInteger('capacity')->nullable();
+            $table->json('attributes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('resources');
+    }
+};

--- a/database/migrations/2025_08_18_130200_create_slots_table.php
+++ b/database/migrations/2025_08_18_130200_create_slots_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('slots', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('resource_id')->constrained()->cascadeOnDelete();
+            $table->dateTime('start_at');
+            $table->dateTime('end_at');
+            $table->boolean('is_available')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('slots');
+    }
+};

--- a/database/migrations/2025_08_18_130300_create_vessels_table.php
+++ b/database/migrations/2025_08_18_130300_create_vessels_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('vessels', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_id')->constrained('users')->cascadeOnDelete();
+            $table->string('name');
+            $table->float('length')->nullable();
+            $table->float('width')->nullable();
+            $table->json('attributes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('vessels');
+    }
+};

--- a/database/migrations/2025_08_18_130400_create_bookings_table.php
+++ b/database/migrations/2025_08_18_130400_create_bookings_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('bookings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('client_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('vessel_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('property_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('resource_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('slot_id')->nullable()->constrained()->nullOnDelete();
+            $table->dateTime('start_at');
+            $table->dateTime('end_at');
+            $table->string('status');
+            $table->string('type')->nullable();
+            $table->string('priority')->nullable();
+            $table->dateTime('hold_expires_at')->nullable();
+            $table->text('notes')->nullable();
+            $table->text('admin_notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bookings');
+    }
+};

--- a/database/migrations/2025_08_18_130500_create_booking_logs_table.php
+++ b/database/migrations/2025_08_18_130500_create_booking_logs_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('booking_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('booking_id')->constrained()->cascadeOnDelete();
+            $table->string('status');
+            $table->text('notes')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('booking_logs');
+    }
+};

--- a/database/migrations/2025_08_18_130600_create_contracts_table.php
+++ b/database/migrations/2025_08_18_130600_create_contracts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('contracts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('booking_id')->constrained()->cascadeOnDelete();
+            $table->string('status');
+            $table->date('effective_from');
+            $table->date('effective_to')->nullable();
+            $table->json('terms_json')->nullable();
+            $table->decimal('total', 10, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('contracts');
+    }
+};

--- a/database/migrations/2025_08_18_130700_create_invoices_table.php
+++ b/database/migrations/2025_08_18_130700_create_invoices_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('invoices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('contract_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('booking_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('invoice_no')->nullable();
+            $table->string('status');
+            $table->string('currency', 3)->default('USD');
+            $table->decimal('total', 10, 2)->default(0);
+            $table->dateTime('issued_at')->nullable();
+            $table->dateTime('due_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invoices');
+    }
+};

--- a/database/migrations/2025_08_18_130800_create_invoice_lines_table.php
+++ b/database/migrations/2025_08_18_130800_create_invoice_lines_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('invoice_lines', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('invoice_id')->constrained()->cascadeOnDelete();
+            $table->string('description');
+            $table->unsignedInteger('qty');
+            $table->decimal('unit_price', 10, 2);
+            $table->decimal('tax_rate', 5, 2)->default(0);
+            $table->decimal('amount', 10, 2);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invoice_lines');
+    }
+};

--- a/database/migrations/2025_08_18_130900_create_payments_table.php
+++ b/database/migrations/2025_08_18_130900_create_payments_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('payments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('invoice_id')->constrained()->cascadeOnDelete();
+            $table->string('method');
+            $table->decimal('amount', 10, 2);
+            $table->dateTime('paid_at');
+            $table->string('reference')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payments');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +11,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        $this->call([
+            RolesAndPermissionsSeeder::class,
+            DemoDataSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DemoDataSeeder.php
+++ b/database/seeders/DemoDataSeeder.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Booking;
+use App\Models\Contract;
+use App\Models\Invoice;
+use App\Models\InvoiceLine;
+use App\Models\Property;
+use App\Models\Resource;
+use App\Models\Slot;
+use App\Models\User;
+use App\Models\Vessel;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class DemoDataSeeder extends Seeder
+{
+    public function run(): void
+    {
+        // Create users
+        $admin = User::firstOrCreate(
+            ['email' => 'admin@example.com'],
+            ['name' => 'Admin', 'password' => Hash::make('password')]
+        );
+        $admin->assignRole('admin');
+
+        $client = User::firstOrCreate(
+            ['email' => 'client@example.com'],
+            ['name' => 'Client', 'password' => Hash::make('password')]
+        );
+        $client->assignRole('client');
+
+        // Property hierarchy
+        $property = Property::create(['name' => 'Demo Marina', 'code' => 'MAR1', 'address' => 'Dock 1']);
+        $resource = Resource::create(['property_id' => $property->id, 'name' => 'Slip A1', 'capacity' => 1]);
+        $slotStart = now()->addDay();
+        $slotEnd = (clone $slotStart)->addHours(2);
+        $slot = Slot::create([
+            'resource_id' => $resource->id,
+            'start_at' => $slotStart,
+            'end_at' => $slotEnd,
+        ]);
+
+        $vessel = Vessel::create(['client_id' => $client->id, 'name' => 'Sea Breeze']);
+
+        $booking = Booking::create([
+            'client_id' => $client->id,
+            'vessel_id' => $vessel->id,
+            'property_id' => $property->id,
+            'resource_id' => $resource->id,
+            'slot_id' => $slot->id,
+            'start_at' => $slotStart,
+            'end_at' => $slotEnd,
+            'status' => 'approved',
+            'type' => 'standard',
+            'priority' => 'normal',
+        ]);
+        $booking->logs()->create(['status' => 'approved', 'notes' => 'Seeded']);
+
+        $contract = Contract::create([
+            'booking_id' => $booking->id,
+            'status' => 'active',
+            'effective_from' => now()->toDateString(),
+            'total' => 1000,
+        ]);
+
+        $invoice = Invoice::create([
+            'contract_id' => $contract->id,
+            'status' => 'draft',
+            'currency' => 'USD',
+            'total' => 1000,
+        ]);
+
+        InvoiceLine::create([
+            'invoice_id' => $invoice->id,
+            'description' => 'Docking Fee',
+            'qty' => 1,
+            'unit_price' => 1000,
+            'tax_rate' => 0,
+            'amount' => 1000,
+        ]);
+    }
+}

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class RolesAndPermissionsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $permissions = [
+            'manage properties',
+            'manage resources',
+            'manage slots',
+            'manage bookings',
+            'approve bookings',
+            'manage contracts',
+            'manage invoices',
+        ];
+
+        foreach ($permissions as $perm) {
+            Permission::firstOrCreate(['name' => $perm]);
+        }
+
+        $roles = [
+            'admin' => $permissions,
+            'agent' => ['manage bookings', 'approve bookings'],
+            'client' => [],
+        ];
+
+        foreach ($roles as $role => $perms) {
+            $r = Role::firstOrCreate(['name' => $role]);
+            $r->syncPermissions($perms);
+        }
+    }
+}

--- a/tests/Feature/BookingFlowTest.php
+++ b/tests/Feature/BookingFlowTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\ExpireBookingHolds;
+use App\Models\Booking;
+use App\Models\Property;
+use App\Models\Resource;
+use App\Models\Slot;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BookingFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_expire_booking_holds_command(): void
+    {
+        $user = User::factory()->create();
+        $property = Property::create(['name' => 'Test', 'code' => 'T1']);
+        $resource = Resource::create(['property_id' => $property->id, 'name' => 'R1']);
+        $start = Carbon::now();
+        $end = (clone $start)->addHour();
+        $slot = Slot::create(['resource_id' => $resource->id, 'start_at' => $start, 'end_at' => $end]);
+
+        $booking = Booking::create([
+            'client_id' => $user->id,
+            'property_id' => $property->id,
+            'resource_id' => $resource->id,
+            'slot_id' => $slot->id,
+            'start_at' => $start,
+            'end_at' => $end,
+            'status' => 'on_hold',
+            'hold_expires_at' => Carbon::now()->subHour(),
+        ]);
+
+        $this->artisan('bookings:expire-holds')
+            ->expectsOutput('Released 1 booking holds.')
+            ->assertExitCode(0);
+
+        $booking->refresh();
+        $this->assertNull($booking->hold_expires_at);
+        $this->assertEquals('requested', $booking->status);
+    }
+}


### PR DESCRIPTION
## Summary
- define config-driven dictionaries and booking settings
- scaffold core domain models, migrations, and seeders
- add booking hold expiration command and schedule

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68a32a6f5f748332b14be724889b0de1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced core booking domain: properties, resources, time slots, vessels, bookings, logs.
  - Added automatic release of expired booking holds via an hourly background task.
  - Added contracts, invoices, invoice lines, and payments.
  - Enabled role-based access (admin, agent, client).

- Documentation
  - Quick Start now includes demo accounts info and a configuration reference for dictionaries/settings.

- Seed Data
  - Added initial roles/permissions and a demo dataset to explore the end-to-end booking and billing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->