### PR TITLE
feat: add configurable app types and settings tables

### DIFF
--- a/app/Models/AppType.php
+++ b/app/Models/AppType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AppType extends Model
+{
+    use HasFactory;
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id', 'group', 'code', 'label', 'extra', 'is_active',
+    ];
+
+    protected $casts = [
+        'extra' => 'array',
+        'is_active' => 'boolean',
+    ];
+}

--- a/app/Models/Booking.php
+++ b/app/Models/Booking.php
@@ -55,7 +55,7 @@ class Booking extends Model
 
     public function setStatusAttribute($value)
     {
-        if (!Dictionary::isValid('booking_statuses', $value)) {
+        if (!Dictionary::isValid('booking_status', $value)) {
             throw new \InvalidArgumentException('Invalid booking status');
         }
         $this->attributes['status'] = $value;

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    protected $primaryKey = 'key';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = ['key', 'value'];
+
+    protected $casts = [
+        'value' => 'array',
+    ];
+}

--- a/app/Support/Dictionary.php
+++ b/app/Support/Dictionary.php
@@ -2,25 +2,33 @@
 
 namespace App\Support;
 
+use App\Models\AppType;
+use Illuminate\Support\Facades\Cache;
+
 class Dictionary
 {
-    public static function options(string $key): array
+    public static function options(string $group): array
     {
-        return config("nautica.dictionaries.$key", []);
+        return Cache::remember("app_types.$group", 60, fn () =>
+            AppType::where('group', $group)
+                ->where('is_active', true)
+                ->pluck('label', 'code')
+                ->toArray()
+        );
     }
 
-    public static function label(string $key, string $value, ?string $default = null): ?string
+    public static function label(string $group, string $code, ?string $default = null): ?string
     {
-        return self::options($key)[$value] ?? $default;
+        return self::options($group)[$code] ?? $default;
     }
 
-    public static function keys(string $key): array
+    public static function keys(string $group): array
     {
-        return array_keys(self::options($key));
+        return array_keys(self::options($group));
     }
 
-    public static function isValid(string $key, string $value): bool
+    public static function isValid(string $group, string $code): bool
     {
-        return in_array($value, self::keys($key), true);
+        return in_array($code, self::keys($group), true);
     }
 }

--- a/config/nautica.php
+++ b/config/nautica.php
@@ -8,40 +8,6 @@ return [
         ],
     ],
 
-    'dictionaries' => [
-        'booking_statuses' => [
-            'requested' => 'Requested',
-            'on_hold' => 'On Hold',
-            'approved' => 'Approved',
-            'rejected' => 'Rejected',
-            'cancelled' => 'Cancelled',
-        ],
-        'booking_types' => [
-            'standard' => 'Standard',
-            'emergency' => 'Emergency',
-        ],
-        'priority_levels' => [
-            'normal' => 'Normal',
-            'high' => 'High',
-        ],
-        'contract_statuses' => [
-            'draft' => 'Draft',
-            'active' => 'Active',
-            'terminated' => 'Terminated',
-        ],
-        'invoice_statuses' => [
-            'draft' => 'Draft',
-            'sent' => 'Sent',
-            'paid' => 'Paid',
-            'void' => 'Void',
-        ],
-        'payment_methods' => [
-            'bank_transfer' => 'Bank Transfer',
-            'card' => 'Card',
-            'cash' => 'Cash',
-        ],
-    ],
-
     'schedule' => [
         'views' => [
             'daily' => 'Daily',

--- a/database/migrations/2025_08_18_131000_create_app_types_table.php
+++ b/database/migrations/2025_08_18_131000_create_app_types_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('app_types', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('group');
+            $table->string('code');
+            $table->string('label');
+            $table->json('extra')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['group', 'code']);
+            $table->index('group');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('app_types');
+    }
+};

--- a/database/migrations/2025_08_18_131100_create_settings_table.php
+++ b/database/migrations/2025_08_18_131100_create_settings_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->json('value');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/seeders/AppTypeSeeder.php
+++ b/database/seeders/AppTypeSeeder.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\AppType;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class AppTypeSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $types = [
+            'org_type' => [
+                ['code' => 'owner', 'label' => 'Owner'],
+                ['code' => 'operator', 'label' => 'Operator'],
+                ['code' => 'agent', 'label' => 'Agent'],
+            ],
+            'booking_type' => [
+                ['code' => 'hourly', 'label' => 'Hourly'],
+                ['code' => 'daily', 'label' => 'Daily'],
+                ['code' => 'monthly', 'label' => 'Monthly'],
+                ['code' => 'yearly', 'label' => 'Yearly'],
+            ],
+            'booking_status' => [
+                ['code' => 'requested', 'label' => 'Requested'],
+                ['code' => 'approved', 'label' => 'Approved'],
+                ['code' => 'confirmed', 'label' => 'Confirmed'],
+                ['code' => 'cancelled', 'label' => 'Cancelled'],
+                ['code' => 'checked_in', 'label' => 'Checked In'],
+                ['code' => 'checked_out', 'label' => 'Checked Out'],
+            ],
+            'invoice_status' => [
+                ['code' => 'draft', 'label' => 'Draft'],
+                ['code' => 'issued', 'label' => 'Issued'],
+                ['code' => 'paid', 'label' => 'Paid'],
+                ['code' => 'void', 'label' => 'Void'],
+            ],
+            'payment_method' => [
+                ['code' => 'cash', 'label' => 'Cash'],
+                ['code' => 'bank', 'label' => 'Bank'],
+                ['code' => 'gateway', 'label' => 'Gateway'],
+            ],
+            'payment_status' => [
+                ['code' => 'pending', 'label' => 'Pending'],
+                ['code' => 'succeeded', 'label' => 'Succeeded'],
+                ['code' => 'failed', 'label' => 'Failed'],
+                ['code' => 'refunded', 'label' => 'Refunded'],
+            ],
+            'service_status' => [
+                ['code' => 'requested', 'label' => 'Requested'],
+                ['code' => 'scheduled', 'label' => 'Scheduled'],
+                ['code' => 'completed', 'label' => 'Completed'],
+                ['code' => 'cancelled', 'label' => 'Cancelled'],
+            ],
+            'service_unit' => [
+                ['code' => 'hour', 'label' => 'Hour'],
+                ['code' => 'job', 'label' => 'Job'],
+                ['code' => 'ton', 'label' => 'Ton'],
+            ],
+            'tax_rate' => [
+                ['code' => 'zero', 'label' => 'Zero'],
+                ['code' => 'standard', 'label' => 'Standard'],
+            ],
+            'size_unit' => [
+                ['code' => 'sqm', 'label' => 'Square Meter'],
+                ['code' => 'sqft', 'label' => 'Square Foot'],
+                ['code' => 'm', 'label' => 'Meter'],
+            ],
+            'user_role' => [
+                ['code' => 'admin', 'label' => 'Admin'],
+                ['code' => 'client', 'label' => 'Client'],
+                ['code' => 'superadmin', 'label' => 'Super Admin'],
+                ['code' => 'pending', 'label' => 'Pending'],
+                ['code' => 'rejected', 'label' => 'Rejected'],
+            ],
+        ];
+
+        foreach ($types as $group => $items) {
+            foreach ($items as $item) {
+                AppType::updateOrCreate(
+                    ['group' => $group, 'code' => $item['code']],
+                    [
+                        'id' => Str::uuid()->toString(),
+                        'label' => $item['label'],
+                        'is_active' => true,
+                    ]
+                );
+            }
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,6 +12,8 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call([
+            AppTypeSeeder::class,
+            SettingsSeeder::class,
             RolesAndPermissionsSeeder::class,
             DemoDataSeeder::class,
         ]);

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Setting;
+use Illuminate\Database\Seeder;
+
+class SettingsSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $settings = [
+            'booking.hold_minutes' => 120,
+            'billing.cycle_day' => 1,
+            'invoice.number_prefix' => 'INV-',
+        ];
+
+        foreach ($settings as $key => $value) {
+            Setting::updateOrCreate(
+                ['key' => $key],
+                ['value' => $value]
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `app_types` and `settings` tables with UUID keys
- seed base booking/payment/status types and settings
- load dictionaries from database instead of hardcoded config

## Testing
- `php -l app/Models/AppType.php app/Models/Setting.php app/Support/Dictionary.php app/Models/Booking.php database/seeders/AppTypeSeeder.php database/seeders/SettingsSeeder.php database/seeders/DatabaseSeeder.php database/migrations/2025_08_18_131000_create_app_types_table.php database/migrations/2025_08_18_131100_create_settings_table.php`
- `php artisan test` *(fails: Class "Illuminate\Foundation\Application" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4225cdc2c83328c14c70817b5333d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic, database-driven dictionaries for statuses, types, and labels across the app.
  - Centralized application settings with seeded defaults (booking hold time, billing cycle day, invoice prefix).
- Bug Fixes
  - Booking status validation aligned with available options to prevent invalid selections.
- Chores
  - Added initial schema and seed data to support dictionaries and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->