### PR TITLE
Add event-driven Zones management

### DIFF
--- a/app/Livewire/Admin/Configuration/Forms/ZoneDelete.php
+++ b/app/Livewire/Admin/Configuration/Forms/ZoneDelete.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Livewire\Admin\Configuration\Forms;
+
+use App\Models\Zone;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\DB;
+use Livewire\Component;
+
+class ZoneDelete extends Component
+{
+    use AuthorizesRequests;
+
+    public bool $showModal = false;
+    public ?Zone $zone = null;
+
+    protected $listeners = [
+        'zone:delete' => 'confirm',
+    ];
+
+    public function confirm(string $zoneId): void
+    {
+        $this->zone = Zone::with('slots')->find($zoneId);
+        if (!$this->zone) {
+            return;
+        }
+
+        $this->authorize('delete', $this->zone);
+        $this->showModal = true;
+    }
+
+    public function delete(): void
+    {
+        if (!$this->zone) {
+            return;
+        }
+
+        if ($this->zone->slots()->exists()) {
+            session()->flash('error', "Cannot delete zone '{$this->zone->name}' because it has associated slots.");
+            $this->closeModal();
+            return;
+        }
+
+        try {
+            DB::transaction(function () {
+                $name = $this->zone->name;
+                $this->zone->delete();
+
+                session()->flash('message', "Zone '{$name}' deleted successfully!");
+                $this->dispatch('zone:deleted');
+            });
+
+            $this->closeModal();
+        } catch (\Exception $e) {
+            \Log::error('Zone deletion failed', [
+                'zone_id' => $this->zone->id,
+                'zone_name' => $this->zone->name,
+                'error' => $e->getMessage(),
+            ]);
+
+            session()->flash('error', 'Failed to delete zone. Please try again or contact support if the issue persists.');
+        }
+    }
+
+    public function closeModal(): void
+    {
+        $this->showModal = false;
+        $this->zone = null;
+        $this->dispatchBrowserEvent('zone-delete:closed');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.configuration.forms.zone-delete');
+    }
+}
+

--- a/app/Livewire/Admin/Configuration/Forms/ZoneDelete.php
+++ b/app/Livewire/Admin/Configuration/Forms/ZoneDelete.php
@@ -34,6 +34,11 @@ class ZoneDelete extends Component
         if (!$this->zone) {
             return;
         }
+        // Re-assert authorization in case delete() is invoked directly.
+        $this->authorize('delete', $this->zone);
+
+        // ...existing deletion logic...
+    }
 
         if ($this->zone->slots()->exists()) {
             session()->flash('error', "Cannot delete zone '{$this->zone->name}' because it has associated slots.");

--- a/app/Livewire/Admin/Configuration/Forms/ZoneForm.php
+++ b/app/Livewire/Admin/Configuration/Forms/ZoneForm.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Livewire\Admin\Configuration\Forms;
+
+use App\Models\Block;
+use App\Models\Zone;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Livewire\Component;
+
+class ZoneForm extends Component
+{
+    use AuthorizesRequests;
+
+    public bool $showModal = false;
+    public ?Zone $editingZone = null;
+
+    public $block_id = '';
+    public $name = '';
+    public $code = '';
+    public $location = '';
+    public bool $is_active = true;
+
+    protected $listeners = [
+        'zone:create' => 'create',
+        'zone:edit' => 'edit',
+    ];
+
+    protected function rules(): array
+    {
+        $uniqueRule = Rule::unique('zones', 'code')
+            ->where(fn($q) => $q->where('block_id', $this->block_id));
+
+        if ($this->editingZone) {
+            $uniqueRule->ignore($this->editingZone->id);
+        }
+
+        return [
+            'block_id' => 'required|exists:blocks,id',
+            'name' => 'required|string|max:255',
+            'code' => ['required', 'string', 'max:50', $uniqueRule],
+            'location' => 'nullable|string|max:255',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    public function create(): void
+    {
+        $this->authorize('create', Zone::class);
+        $this->resetForm();
+        $this->showModal = true;
+    }
+
+    public function edit(string $zoneId): void
+    {
+        $zone = Zone::find($zoneId);
+        if (!$zone) {
+            return;
+        }
+
+        $this->authorize('update', $zone);
+
+        $this->editingZone = $zone;
+        $this->block_id = $zone->block_id;
+        $this->name = $zone->name;
+        $this->code = $zone->code;
+        $this->location = $zone->location;
+        $this->is_active = $zone->is_active;
+        $this->showModal = true;
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+
+        try {
+            DB::transaction(function () {
+                $data = [
+                    'block_id' => $this->block_id,
+                    'name' => $this->name,
+                    'code' => $this->code,
+                    'location' => $this->location,
+                    'is_active' => $this->is_active,
+                ];
+
+                if ($this->editingZone) {
+                    $this->editingZone->update($data);
+                    session()->flash('message', 'Zone updated successfully!');
+                } else {
+                    Zone::create($data);
+                    session()->flash('message', 'Zone created successfully!');
+                }
+
+                $this->dispatch('zone:saved');
+            });
+
+            $this->closeModal();
+        } catch (\Exception $e) {
+            \Log::error('Zone save failed', [
+                'zone_id' => $this->editingZone?->id,
+                'data' => [
+                    'block_id' => $this->block_id,
+                    'name' => $this->name,
+                    'code' => $this->code,
+                ],
+                'error' => $e->getMessage(),
+            ]);
+
+            session()->flash('error', 'Failed to save zone. Please check your input and try again.');
+        }
+    }
+
+    public function closeModal(): void
+    {
+        $this->showModal = false;
+        $this->resetForm();
+        $this->dispatchBrowserEvent('zone-form:closed');
+    }
+
+    protected function resetForm(): void
+    {
+        $this->editingZone = null;
+        $this->block_id = '';
+        $this->name = '';
+        $this->code = '';
+        $this->location = '';
+        $this->is_active = true;
+        $this->resetErrorBag();
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.configuration.forms.zone-form', [
+            'blocks' => Block::with('property')->where('is_active', true)->get(),
+        ]);
+    }
+}
+

--- a/app/Livewire/Admin/Configuration/Zones.php
+++ b/app/Livewire/Admin/Configuration/Zones.php
@@ -3,7 +3,6 @@
 namespace App\Livewire\Admin\Configuration;
 
 use App\Models\Zone;
-use App\Models\Block;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -11,109 +10,73 @@ class Zones extends Component
 {
     use WithPagination;
 
-    public $showModal = false;
-    public $editingZone = null;
-    
-    public $block_id = '';
-    public $name = '';
-    public $code = '';
-    public $location = '';
-    public $notes = '';
-    public $is_active = true;
+    public string $search = '';
+    public bool $showInactive = false;
+    public int $perPage = 10;
 
-    protected $rules = [
-        'block_id' => 'required|exists:blocks,id',
-        'name' => 'required|string|max:255',
-        'code' => 'required|string|max:50',
-        'location' => 'nullable|string|max:255',
-        'notes' => 'nullable|string',
-        'is_active' => 'boolean',
+    protected $listeners = [
+        'zone:saved' => '$refresh',
+        'zone:deleted' => '$refresh',
     ];
 
-    public function create()
+    public function create(): void
     {
-        $this->resetForm();
-        $this->showModal = true;
+        $this->dispatch('zone:create');
     }
 
-    public function edit(Zone $zone)
+    public function edit(string $zoneId): void
     {
-        $this->editingZone = $zone;
-        $this->block_id = $zone->block_id;
-        $this->name = $zone->name;
-        $this->code = $zone->code;
-        $this->location = $zone->location;
-        $this->notes = $zone->notes;
-        $this->is_active = $zone->is_active;
-        $this->showModal = true;
+        $this->dispatch('zone:edit', $zoneId);
     }
 
-    public function save()
+    public function delete(string $zoneId): void
     {
-        $this->validate();
-
-        // Check unique constraint for block_id + code
-        $query = Zone::where('block_id', $this->block_id)
-                     ->where('code', $this->code);
-                     
-        if ($this->editingZone) {
-            $query->where('id', '!=', $this->editingZone->id);
-        }
-
-        if ($query->exists()) {
-            $this->addError('code', 'Code must be unique within this block.');
-            return;
-        }
-
-        $data = [
-            'block_id' => $this->block_id,
-            'name' => $this->name,
-            'code' => $this->code,
-            'location' => $this->location,
-            'notes' => $this->notes,
-            'is_active' => $this->is_active,
-        ];
-
-        if ($this->editingZone) {
-            $this->editingZone->update($data);
-            session()->flash('message', 'Zone updated successfully!');
-        } else {
-            Zone::create($data);
-            session()->flash('message', 'Zone created successfully!');
-        }
-
-        $this->closeModal();
+        $this->dispatch('zone:delete', $zoneId);
     }
 
-    public function delete(Zone $zone)
+    public function updatedSearch(): void
     {
-        $zone->delete();
-        session()->flash('message', 'Zone deleted successfully!');
+        $this->resetPage();
     }
 
-    public function closeModal()
+    public function updatedShowInactive(): void
     {
-        $this->showModal = false;
-        $this->resetForm();
+        $this->resetPage();
     }
 
-    protected function resetForm()
+    public function updatedPerPage(): void
     {
-        $this->editingZone = null;
-        $this->block_id = '';
-        $this->name = '';
-        $this->code = '';
-        $this->location = '';
-        $this->notes = '';
-        $this->is_active = true;
-        $this->resetErrorBag();
+        $this->resetPage();
+    }
+
+    public function toggleInactiveFilter(): void
+    {
+        $this->showInactive = !$this->showInactive;
+        $this->resetPage();
     }
 
     public function render()
     {
+        $query = Zone::with('block.property');
+
+        if ($this->search) {
+            $escapedSearch = addcslashes($this->search, '%_\\');
+            $query->where(function ($q) use ($escapedSearch) {
+                $q->where('name', 'like', '%' . $escapedSearch . '%')
+                  ->orWhere('code', 'like', '%' . $escapedSearch . '%')
+                  ->orWhere('location', 'like', '%' . $escapedSearch . '%');
+            });
+        }
+
+        if ($this->showInactive) {
+            $query->where('is_active', false);
+        } else {
+            $query->where('is_active', true);
+        }
+
         return view('livewire.admin.configuration.zones', [
-            'zones' => Zone::with(['block.property', 'slots'])->paginate(10),
-            'blocks' => Block::with('property')->where('is_active', true)->get()
+            'zones' => $query->paginate($this->perPage),
         ]);
     }
 }
+

--- a/docs/CHANGELOG-configuration.md
+++ b/docs/CHANGELOG-configuration.md
@@ -5,6 +5,10 @@
 - Updated blocks index view with search, active filter, responsive tables, and action buttons.
 - Mounted new Block form/delete components in configuration index container.
 - Added "Configuration" shortcut button on the admin dashboard header for admins.
+- Added event-driven CRUD for Zones with dedicated form and delete Livewire components.
+- Zones index view now supports search (name/code/location), active filter, per-page selection, responsive tables, and event-driven actions.
+- Mounted Zone form/delete components in configuration index container.
+- Zone deletion prevented when associated Slots exist.
 
 ## Notes
 - Further entities (Zones, Slots, Settings, App Types) still require migration to the new pattern.

--- a/resources/views/livewire/admin/configuration/forms/zone-delete.blade.php
+++ b/resources/views/livewire/admin/configuration/forms/zone-delete.blade.php
@@ -1,0 +1,30 @@
+<div>
+@if($showModal)
+    <div class="fixed inset-0 z-50 flex items-center justify-center p-4"
+         x-data
+         x-init="$nextTick(() => { document.body.style.overflow='hidden' })"
+         x-on:keydown.escape.window="$wire.closeModal()"
+         x-on:zone-delete:closed.window="$nextTick(() => { document.body.style.overflow=''; })"
+         wire:ignore.self>
+        <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" wire:click="closeModal"></div>
+        <div class="relative w-full max-w-md" style="background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 25px 50px -12px rgba(0,0,0,0.25); animation:modal-appear .2s ease-out;">
+            <div class="px-6 py-4 border-b" style="border-color:var(--border);">
+                <h3 class="text-lg font-semibold" style="color:var(--foreground);">Delete Zone</h3>
+            </div>
+            <div class="px-6 py-4">
+                <p class="text-sm" style="color:var(--foreground);">
+                    Are you sure you want to delete <span class="font-semibold">{{ $zone?->name }}</span>? This action cannot be undone.
+                </p>
+            </div>
+            <div class="flex items-center justify-end gap-3 px-6 py-4 border-t" style="border-color:var(--border);">
+                <button type="button" wire:click="closeModal" class="btn-secondary">Cancel</button>
+                <button type="button" wire:click="delete" class="btn-destructive">Delete</button>
+            </div>
+        </div>
+    </div>
+    <style>
+        @keyframes modal-appear {from {opacity:0; transform:scale(0.95) translateY(-10px);} to {opacity:1; transform:scale(1) translateY(0);}}
+    </style>
+@endif
+</div>
+

--- a/resources/views/livewire/admin/configuration/forms/zone-form.blade.php
+++ b/resources/views/livewire/admin/configuration/forms/zone-form.blade.php
@@ -1,0 +1,64 @@
+<div>
+@if($showModal)
+    <div class="fixed inset-0 z-50 flex items-center justify-center p-4"
+         x-data
+         x-init="$nextTick(() => { document.body.style.overflow='hidden' })"
+         x-on:keydown.escape.window="$wire.closeModal()"
+         x-on:zone-form:closed.window="$nextTick(() => { document.body.style.overflow=''; })"
+         wire:ignore.self>
+        <div class="absolute inset-0 bg-black/50 backdrop-blur-sm" wire:click="closeModal"></div>
+        <div class="relative w-full max-w-xl" style="background: var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 25px 50px -12px rgba(0,0,0,0.25); animation:modal-appear .2s ease-out;">
+            <div class="flex items-center justify-between px-6 py-4 border-b" style="border-color:var(--border);">
+                <h3 class="text-lg font-semibold" style="color:var(--foreground);">{{ $editingZone ? 'Edit Zone' : 'Create Zone' }}</h3>
+                <button wire:click="closeModal" class="p-2 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-800">
+                    <x-heroicon name="x-mark" class="w-5 h-5" style="color:var(--muted-foreground);" />
+                </button>
+            </div>
+            <form wire:submit.prevent="save" class="px-6 py-4">
+                <div class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium mb-2" style="color:var(--foreground);">Block</label>
+                        <select wire:model="block_id" class="form-input">
+                            <option value="">Select block</option>
+                            @foreach($blocks as $block)
+                                <option value="{{ $block->id }}">{{ $block->name }} ({{ $block->property->name }})</option>
+                            @endforeach
+                        </select>
+                        @error('block_id') <span class="text-sm mt-1 text-red-600">{{ $message }}</span> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium mb-2" style="color:var(--foreground);">Zone Code</label>
+                        <input type="text" wire:model="code" class="form-input" placeholder="Enter unique code">
+                        @error('code') <span class="text-sm mt-1 text-red-600">{{ $message }}</span> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium mb-2" style="color:var(--foreground);">Zone Name</label>
+                        <input type="text" wire:model="name" class="form-input" placeholder="Enter zone name">
+                        @error('name') <span class="text-sm mt-1 text-red-600">{{ $message }}</span> @enderror
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium mb-2" style="color:var(--foreground);">Location</label>
+                        <input type="text" wire:model="location" class="form-input" placeholder="e.g., North Section">
+                        @error('location') <span class="text-sm mt-1 text-red-600">{{ $message }}</span> @enderror
+                    </div>
+                    <div class="flex items-center">
+                        <input type="checkbox" wire:model="is_active" class="rounded border-gray-300 text-blue-600 shadow-sm focus:border-blue-300 focus:ring focus:ring-blue-200 focus:ring-opacity-50" id="zone_is_active">
+                        <label for="zone_is_active" class="ml-2 text-sm" style="color:var(--foreground);">Zone is active</label>
+                    </div>
+                </div>
+                <div class="flex items-center justify-end gap-3 mt-6 pt-4 border-t" style="border-color:var(--border);">
+                    <button type="button" wire:click="closeModal" class="btn-secondary">Cancel</button>
+                    <button type="submit" class="btn">{{ $editingZone ? 'Update Zone' : 'Create Zone' }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+    <style>
+        @keyframes modal-appear {
+            from {opacity:0; transform:scale(0.95) translateY(-10px);}
+            to {opacity:1; transform:scale(1) translateY(0);}
+        }
+    </style>
+@endif
+</div>
+

--- a/resources/views/livewire/admin/configuration/index.blade.php
+++ b/resources/views/livewire/admin/configuration/index.blade.php
@@ -123,4 +123,6 @@
     @livewire('admin.configuration.forms.property-delete')
     @livewire('admin.configuration.forms.block-form')
     @livewire('admin.configuration.forms.block-delete')
+    @livewire('admin.configuration.forms.zone-form')
+    @livewire('admin.configuration.forms.zone-delete')
 </div>

--- a/resources/views/livewire/admin/configuration/zones.blade.php
+++ b/resources/views/livewire/admin/configuration/zones.blade.php
@@ -1,26 +1,132 @@
-<div>
-    <!-- Header with Action Button -->
-    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1.5rem;">
-        <div>
-            <h3 style="font-size: 1.25rem; font-weight: 600; color: var(--foreground); margin: 0;">Zones Management</h3>
-            <p style="color: var(--muted-foreground); font-size: 0.875rem; margin: 0;">Define zones within blocks for precise area organization</p>
+{{-- resources/views/livewire/admin/configuration/zones.blade.php --}}
+<div class="zones-panel space-y-6">
+    <div class="flex flex-col gap-4">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+            <div class="min-w-0">
+                <h3 class="text-lg sm:text-xl font-semibold" style="color: var(--foreground);">Zones Management</h3>
+                <p class="text-sm" style="color: var(--muted-foreground);">Manage block zones and their locations</p>
+            </div>
         </div>
-        <button wire:click="create" class="btn" style="font-size: 0.875rem;">
-            <x-heroicon name="plus" class="w-4 h-4" />
-            Add Zone
-        </button>
+        <div class="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center">
+            <div class="relative flex-1 max-w-md">
+                <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                    <x-heroicon name="magnifying-glass" class="w-4 h-4" style="color: var(--muted-foreground);" />
+                </div>
+                <input type="text" wire:model.live.debounce.300ms="search" placeholder="Search by name, code or location..." class="form-input pl-10 h-10 text-sm">
+            </div>
+            <button wire:click="toggleInactiveFilter" class="inline-flex items-center gap-2 px-3 py-2 h-10 text-sm rounded-xl border transition-all hover:-translate-y-0.5 {{ $showInactive ? 'border-orange-300 text-orange-600 hover:bg-orange-50 dark:border-orange-700 dark:text-orange-400 dark:hover:bg-orange-900/10' : 'border-green-300 text-green-600 hover:bg-green-50 dark:border-green-700 dark:text-green-400 dark:hover:bg-green-900/10' }}" style="background-color: var(--card);">
+                <div class="w-2 h-2 rounded-full {{ $showInactive ? 'bg-orange-500' : 'bg-green-500' }}"></div>
+                <span class="whitespace-nowrap">{{ $showInactive ? 'Show Inactive' : 'Show Active' }}</span>
+            </button>
+            <select wire:model="perPage" class="form-input w-24 h-10 text-sm">
+                <option value="10">10</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+            </select>
+            <button wire:click="create" class="btn inline-flex items-center gap-2 justify-center px-3 py-2 h-10 text-sm rounded-xl shadow-sm transition-all hover:-translate-y-0.5">
+                <x-heroicon name="plus" class="w-4 h-4" />
+                <span class="hidden sm:inline">Add Zone</span>
+                <span class="sm:hidden">Add</span>
+            </button>
+        </div>
     </div>
 
-    <!-- Flash Messages -->
     @if (session()->has('message'))
-        <div style="background-color: var(--success); color: var(--success-foreground); padding: 1rem; border-radius: var(--radius); margin-bottom: 1rem;">
+        <div class="rounded-xl px-4 py-3 text-sm" style="background-color: var(--success); color: var(--success-foreground);">
             {{ session('message') }}
         </div>
     @endif
+    @if (session()->has('error'))
+        <div class="rounded-xl px-4 py-3 text-sm" style="background-color: var(--destructive); color: var(--destructive-foreground);">
+            {{ session('error') }}
+        </div>
+    @endif
 
-    <div class="table-container">
-        <p style="color: var(--muted-foreground); padding: 2rem; text-align: center;">
-            Zones management interface - detailed implementation coming soon
-        </p>
+    <div class="hidden md:block">
+        <div class="overflow-x-auto rounded-2xl border" style="border-color: var(--border); background: var(--card);">
+            <table class="min-w-full text-sm">
+                <thead>
+                    <tr class="text-left" style="background: color-mix(in oklab, var(--muted) 60%, transparent); color: var(--muted-foreground);">
+                        <th class="px-4 py-3 font-medium">Code</th>
+                        <th class="px-4 py-3 font-medium">Name</th>
+                        <th class="px-4 py-3 font-medium">Location</th>
+                        <th class="px-4 py-3 font-medium">Block</th>
+                        <th class="px-4 py-3 font-medium">Property</th>
+                        <th class="px-4 py-3 font-medium">Status</th>
+                        <th class="px-4 py-3 font-medium text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($zones as $zone)
+                        <tr class="border-top" style="border-color: var(--border); color: var(--foreground);" wire:key="zone-row-{{ $zone->id }}">
+                            <td class="px-4 py-3 align-middle whitespace-nowrap">
+                                <code class="rounded-md px-2 py-1 text-[0.75rem]" style="background-color: var(--muted); color: var(--foreground);">{{ $zone->code }}</code>
+                            </td>
+                            <td class="px-4 py-3 align-middle">
+                                <div class="font-medium truncate">{{ $zone->name }}</div>
+                            </td>
+                            <td class="px-4 py-3 align-middle">
+                                <div class="truncate">{{ $zone->location }}</div>
+                            </td>
+                            <td class="px-4 py-3 align-middle whitespace-nowrap">{{ $zone->block->name }}</td>
+                            <td class="px-4 py-3 align-middle whitespace-nowrap">{{ $zone->block->property->name }}</td>
+                            <td class="px-4 py-3 align-middle"><span class="badge {{ $zone->is_active ? 'success' : 'secondary' }}">{{ $zone->is_active ? 'Active' : 'Inactive' }}</span></td>
+                            <td class="px-4 py-3 align-middle">
+                                <div class="flex items-center justify-end gap-2">
+                                    <button wire:click="edit('{{ $zone->id }}')" class="btn-secondary inline-flex items-center justify-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg min-w-[4.5rem]" aria-label="Edit {{ $zone->name }}">
+                                        <x-heroicon name="pencil" class="w-4 h-4" />
+                                        <span>Edit</span>
+                                    </button>
+                                    <button wire:click="delete('{{ $zone->id }}')" class="btn-destructive inline-flex items-center justify-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg min-w-[4.5rem]" aria-label="Delete {{ $zone->name }}">
+                                        <x-heroicon name="trash" class="w-4 h-4" />
+                                        <span>Delete</span>
+                                    </button>
+                                </div>
+                            </td>
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="7" class="px-4 py-6 text-center text-sm" style="color: var(--muted-foreground);">No zones found.</td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <div class="md:hidden space-y-3">
+        @forelse($zones as $zone)
+            <div class="p-4 rounded-xl border" style="border-color: var(--border); background: var(--card);" wire:key="zone-card-{{ $zone->id }}">
+                <div class="flex items-center justify-between mb-2">
+                    <h4 class="font-semibold" style="color: var(--foreground);">{{ $zone->name }}</h4>
+                    <span class="badge {{ $zone->is_active ? 'success' : 'secondary' }}">{{ $zone->is_active ? 'Active' : 'Inactive' }}</span>
+                </div>
+                <div class="text-sm mb-2" style="color: var(--muted-foreground);">
+                    <div>Code: <code class="px-1 rounded" style="background:var(--muted); color:var(--foreground);">{{ $zone->code }}</code></div>
+                    <div>Block: {{ $zone->block->name }}</div>
+                    <div>Property: {{ $zone->block->property->name }}</div>
+                    @if($zone->location)
+                        <div>Location: {{ $zone->location }}</div>
+                    @endif
+                </div>
+                <div class="flex items-center justify-end gap-2">
+                    <button wire:click="edit('{{ $zone->id }}')" class="btn-secondary inline-flex items-center justify-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg min-w-[4.5rem]">
+                        <x-heroicon name="pencil" class="w-4 h-4" />
+                        <span>Edit</span>
+                    </button>
+                    <button wire:click="delete('{{ $zone->id }}')" class="btn-destructive inline-flex items-center justify-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg min-w-[4.5rem]">
+                        <x-heroicon name="trash" class="w-4 h-4" />
+                        <span>Delete</span>
+                    </button>
+                </div>
+            </div>
+        @empty
+            <div class="text-center text-sm" style="color: var(--muted-foreground);">No zones found.</div>
+        @endforelse
+    </div>
+
+    <div>
+        {{ $zones->links() }}
     </div>
 </div>
+


### PR DESCRIPTION
## Summary
- Implement event-driven Zones listing with search, active filter, and pagination controls
- Introduce ZoneForm and ZoneDelete Livewire components for CRUD with scoped uniqueness and slot guards
- Wire Zones components into configuration index and document changes

## Testing
- `composer test` *(fails: require vendor autoload missing)*
- `composer install` *(fails: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b42563588332825c0a88c7818c84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Modal form to create/edit Zones with validation.
  - Delete confirmation modal with protection when related items exist.
  - Event-driven actions from the Zones list and success/error flash messages.

- Enhancements
  - Zones page adds search (name/code/location), active/inactive toggle, and per-page selector.
  - Responsive UI: table on desktop, cards on mobile; improved pagination and inline status badges.
  - Better UX: backdrop/Escape to close modals.

- Documentation
  - Updated configuration changelog to include new Zones management features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->