### PR TITLE
Add roles permissions manager

### DIFF
--- a/app/Livewire/Admin/Configuration/Roles/Index.php
+++ b/app/Livewire/Admin/Configuration/Roles/Index.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Livewire\Admin\Configuration\Roles;
+
+use Livewire\Component;
+use Spatie\Permission\Models\Role;
+
+class Index extends Component
+{
+    public $selectedRoleId;
+    public $roles;
+
+    public function mount()
+    {
+        $this->roles = Role::orderBy('name')->get();
+        $this->selectedRoleId = $this->roles->first()?->id;
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.configuration.roles.index')
+            ->layout('layouts.app');
+    }
+}

--- a/app/Livewire/Admin/Configuration/Roles/RoleEditor.php
+++ b/app/Livewire/Admin/Configuration/Roles/RoleEditor.php
@@ -95,10 +95,22 @@ class RoleEditor extends Component
 
     public function apply()
     {
-        $this->role->syncPermissions($this->assigned);
-        app(PermissionRegistrar::class)->forgetCachedPermissions();
-        $this->loadRole($this->role->id);
-        $this->dispatch('notify', type: 'success', message: 'Permissions updated');
+        try {
+            $this->role->syncPermissions($this->assigned);
+            app(PermissionRegistrar::class)->forgetCachedPermissions();
+            $this->loadRole($this->role->id);
+            $this->dispatch('notify', type: 'success', message: 'Permissions updated');
+        } catch (\Exception $e) {
+            $this->dispatch(
+                'notify',
+                type: 'error',
+                message: 'Failed to update permissions: ' . $e->getMessage()
+            );
+            \Log::error('Permission sync failed', [
+                'role'  => $this->role->id,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     public function discard()

--- a/app/Livewire/Admin/Configuration/Roles/RoleEditor.php
+++ b/app/Livewire/Admin/Configuration/Roles/RoleEditor.php
@@ -25,10 +25,15 @@ class RoleEditor extends Component
 
     public function loadRole($roleId)
     {
-        $this->role = Role::findOrFail($roleId);
-        $this->assigned = $this->role->permissions->pluck('id')->toArray();
-        $this->original = $this->assigned;
-        $this->dirty = false;
+        try {
+            $this->role = Role::findOrFail($roleId);
+            $this->assigned = $this->role->permissions->pluck('id')->toArray();
+            $this->original = $this->assigned;
+            $this->dirty = false;
+        } catch (\Exception $e) {
+            $this->dispatch('notify', type: 'error', message: 'Failed to load role: ' . $e->getMessage());
+            throw $e;
+        }
     }
 
     public function updatedAssigned()

--- a/app/Livewire/Admin/Configuration/Roles/RoleEditor.php
+++ b/app/Livewire/Admin/Configuration/Roles/RoleEditor.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Livewire\Admin\Configuration\Roles;
+
+use Livewire\Component;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Illuminate\Support\Str;
+
+class RoleEditor extends Component
+{
+    public $roleId;
+    public $role;
+    public $group = 'all';
+    public $search = '';
+    public $assigned = [];
+    public $original = [];
+    public $dirty = false;
+
+    public function mount($roleId)
+    {
+        $this->loadRole($roleId);
+    }
+
+    public function loadRole($roleId)
+    {
+        $this->role = Role::findOrFail($roleId);
+        $this->assigned = $this->role->permissions->pluck('id')->toArray();
+        $this->original = $this->assigned;
+        $this->dirty = false;
+    }
+
+    public function updatedAssigned()
+    {
+        $this->dirty = $this->hasChanges();
+    }
+
+    public function updatedSearch()
+    {
+        $this->resetPageIfApplicable();
+    }
+
+    public function updatedGroup()
+    {
+        $this->resetPageIfApplicable();
+    }
+
+    protected function resetPageIfApplicable()
+    {
+        // placeholder for pagination resets if needed
+    }
+
+    protected function hasChanges()
+    {
+        $current = $this->assigned;
+        $original = $this->original;
+        sort($current);
+        sort($original);
+        return $current !== $original;
+    }
+
+    protected function deriveGroup($name)
+    {
+        return Str::before($name, '.');
+    }
+
+    public function grantAll($group)
+    {
+        $permissions = $this->permissionsQuery()->get()->filter(function ($perm) use ($group) {
+            return $this->deriveGroup($perm->name) === $group;
+        });
+        foreach ($permissions as $perm) {
+            if (!in_array($perm->id, $this->assigned)) {
+                $this->assigned[] = $perm->id;
+            }
+        }
+        $this->updatedAssigned();
+    }
+
+    public function revokeAll($group)
+    {
+        $permissions = $this->permissionsQuery()->get()->filter(function ($perm) use ($group) {
+            return $this->deriveGroup($perm->name) === $group;
+        });
+        $ids = $permissions->pluck('id')->toArray();
+        $this->assigned = array_values(array_diff($this->assigned, $ids));
+        $this->updatedAssigned();
+    }
+
+    public function apply()
+    {
+        $this->role->syncPermissions($this->assigned);
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $this->loadRole($this->role->id);
+        $this->dispatch('notify', type: 'success', message: 'Permissions updated');
+    }
+
+    public function discard()
+    {
+        $this->assigned = $this->original;
+        $this->dirty = false;
+    }
+
+    protected function permissionsQuery()
+    {
+        $query = Permission::query()->where('guard_name', $this->role->guard_name);
+        return $query;
+    }
+
+    public function getPermissionsProperty()
+    {
+        $query = $this->permissionsQuery();
+
+        if ($this->group !== 'all') {
+            $query = $query->get()->filter(function ($perm) {
+                return $this->deriveGroup($perm->name) === $this->group;
+            });
+        } else {
+            $query = $query->get();
+        }
+
+        if ($this->search) {
+            $search = Str::lower($this->search);
+            $query = $query->filter(function ($perm) use ($search) {
+                return Str::contains(Str::lower($perm->name), $search);
+            });
+        }
+
+        return $query->groupBy(fn($perm) => $this->deriveGroup($perm->name));
+    }
+
+    public function getGroupsProperty()
+    {
+        return Permission::where('guard_name', $this->role->guard_name)
+            ->get()
+            ->map(fn($p) => $this->deriveGroup($p->name))
+            ->unique()
+            ->sort()
+            ->values();
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.configuration.roles.role-editor', [
+            'permissionGroups' => $this->permissions,
+            'groups' => $this->groups,
+        ]);
+    }
+}

--- a/docs/CHANGELOG-configuration.md
+++ b/docs/CHANGELOG-configuration.md
@@ -5,6 +5,7 @@
 - Updated blocks index view with search, active filter, responsive tables, and action buttons.
 - Mounted new Block form/delete components in configuration index container.
 - Added "Configuration" shortcut button on the admin dashboard header for admins.
+- Added Roles → Permissions Manager to assign and revoke permissions per role.
 
 ## Notes
 - Further entities (Zones, Slots, Settings, App Types) still require migration to the new pattern.

--- a/resources/views/livewire/admin/configuration/roles/index.blade.php
+++ b/resources/views/livewire/admin/configuration/roles/index.blade.php
@@ -1,0 +1,19 @@
+<div class="config-page p-4 sm:p-6 md:p-8 fade-in">
+    <div class="mb-6 md:mb-8">
+        <h1 class="text-2xl md:text-3xl font-bold sys-title mb-1">Roles — Permissions Manager</h1>
+        <p class="text-sm md:text-base sys-subtitle">Assign and revoke permissions for existing roles</p>
+    </div>
+
+    <div class="mb-4">
+        <label class="block text-sm font-medium mb-1">Select Role</label>
+        <select wire:model="selectedRoleId" class="w-full border sys-border rounded-md p-2">
+            @foreach($roles as $role)
+                <option value="{{ $role->id }}">{{ ucfirst($role->name) }}</option>
+            @endforeach
+        </select>
+    </div>
+
+    @if($selectedRoleId)
+        @livewire('admin.configuration.roles.role-editor', ['roleId' => $selectedRoleId], key('role-'.$selectedRoleId))
+    @endif
+</div>

--- a/resources/views/livewire/admin/configuration/roles/role-editor.blade.php
+++ b/resources/views/livewire/admin/configuration/roles/role-editor.blade.php
@@ -1,0 +1,42 @@
+<div>
+    <div class="flex flex-col md:flex-row gap-4 mb-4">
+        <div class="flex-1">
+            <input type="text" wire:model.debounce.500ms="search" placeholder="Search permissions..." class="w-full border sys-border rounded-md p-2" />
+        </div>
+        <div>
+            <select wire:model="group" class="border sys-border rounded-md p-2">
+                <option value="all">All groups</option>
+                @foreach($groups as $g)
+                    <option value="{{ $g }}">{{ $g }}</option>
+                @endforeach
+            </select>
+        </div>
+    </div>
+
+    <div class="space-y-6">
+        @foreach($permissionGroups as $groupName => $permissions)
+            <div class="border rounded-md p-4">
+                <div class="flex items-center justify-between mb-3">
+                    <h3 class="font-semibold">{{ $groupName }} <span class="text-sm text-gray-500">({{ collect($permissions)->pluck('id')->intersect($assigned)->count() }} / {{ count($permissions) }})</span></h3>
+                    <div class="space-x-2">
+                        <button type="button" wire:click="grantAll('{{ $groupName }}')" class="btn-secondary text-xs">Grant All</button>
+                        <button type="button" wire:click="revokeAll('{{ $groupName }}')" class="btn-secondary text-xs">Revoke All</button>
+                    </div>
+                </div>
+                <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">
+                    @foreach($permissions as $permission)
+                        <label class="flex items-center gap-2">
+                            <input type="checkbox" value="{{ $permission->id }}" wire:model="assigned" class="sys-input">
+                            <span class="text-sm">{{ $permission->name }}</span>
+                        </label>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="mt-6 flex gap-2">
+        <button wire:click="apply" class="btn-primary" @disabled(! $dirty)>Apply Changes</button>
+        <button wire:click="discard" class="btn-secondary" @disabled(! $dirty)>Discard</button>
+    </div>
+</div>

--- a/resources/views/livewire/admin/configuration/roles/role-editor.blade.php
+++ b/resources/views/livewire/admin/configuration/roles/role-editor.blade.php
@@ -19,8 +19,8 @@
                 <div class="flex items-center justify-between mb-3">
                     <h3 class="font-semibold">{{ $groupName }} <span class="text-sm text-gray-500">({{ collect($permissions)->pluck('id')->intersect($assigned)->count() }} / {{ count($permissions) }})</span></h3>
                     <div class="space-x-2">
-                        <button type="button" wire:click="grantAll('{{ $groupName }}')" class="btn-secondary text-xs">Grant All</button>
-                        <button type="button" wire:click="revokeAll('{{ $groupName }}')" class="btn-secondary text-xs">Revoke All</button>
+                        <button type="button" wire:click='grantAll(@js($groupName))' class="btn-secondary text-xs">Grant All</button>
+                        <button type="button" wire:click='revokeAll(@js($groupName))' class="btn-secondary text-xs">Revoke All</button>
                     </div>
                 </div>
                 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-2">

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Livewire\Admin\Dashboard as AdminDashboard;
 use App\Livewire\Admin\Configuration\Index as ConfigurationIndex;
+use App\Livewire\Admin\Configuration\Roles\Index as RolesIndex;
 use App\Livewire\Auth\Login;
 use App\Livewire\Auth\Register;
 use App\Livewire\Client\Dashboard as ClientDashboard;
@@ -25,6 +26,7 @@ Route::post('/logout', [LogoutController::class, '__invoke'])->middleware('auth'
 Route::middleware(['auth', 'admin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('/dashboard', AdminDashboard::class)->name('dashboard');
     Route::get('/configuration', ConfigurationIndex::class)->name('configuration');
+    Route::get('/configuration/roles', RolesIndex::class)->name('configuration.roles');
 });
 
 // Client routes group  


### PR DESCRIPTION
## Summary
- introduce roles permissions manager under admin configuration
- implement per-role editor with search, grouping, and bulk grant/revoke
- document addition in configuration changelog

## Testing
- `php -l app/Livewire/Admin/Configuration/Roles/Index.php app/Livewire/Admin/Configuration/Roles/RoleEditor.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6bb770ae48332982a4719d57f2c2a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Roles → Permissions Manager to assign and revoke permissions per role.
  - Select a role to view its permissions grouped by category, with real-time assigned/total counts.
  - Search permissions, filter by group, and quickly Grant All or Revoke All within a group.
  - Apply or discard changes with clear dirty-state indicators.
  - Accessible via Admin → Configuration → Roles (/admin/configuration/roles).

- Documentation
  - Added changelog entry announcing the Roles → Permissions Manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->