### PR TITLE
feat: improve vessel search configuration

### DIFF
--- a/app/Livewire/Admin/Management/Vessels/VesselForm.php
+++ b/app/Livewire/Admin/Management/Vessels/VesselForm.php
@@ -202,21 +202,21 @@ class VesselForm extends Component
 
     public function loadEligibleClients($ownerSearch = '', $renterSearch = '')
     {
-        $this->eligibleOwners = $this->vesselService->getEligibleClients($ownerSearch, 20)
+        $this->eligibleOwners = $this->vesselService->getEligibleClients($ownerSearch)
             ->map(function ($client) {
                 return [
                     'id' => $client->id,
                     'display_name' => $client->display_name,
-                    'email' => $client->email
+                    'id_card' => $client->id_card,
                 ];
             })->toArray();
 
-        $this->eligibleRenters = $this->vesselService->getEligibleClients($renterSearch, 20)
+        $this->eligibleRenters = $this->vesselService->getEligibleClients($renterSearch)
             ->map(function ($client) {
                 return [
                     'id' => $client->id,
                     'display_name' => $client->display_name,
-                    'email' => $client->email
+                    'id_card' => $client->id_card,
                 ];
             })->toArray();
     }

--- a/config/nautica.php
+++ b/config/nautica.php
@@ -22,5 +22,10 @@ return [
             'utilization' => true,
         ],
     ],
+
+    'vessels' => [
+        'search_limit' => env('VESSEL_SEARCH_LIMIT', 20),
+        'allow_owner_renter_same' => env('VESSEL_ALLOW_OWNER_RENTER_SAME', false),
+    ],
 ];
 

--- a/resources/views/livewire/admin/management/vessels/index.blade.php
+++ b/resources/views/livewire/admin/management/vessels/index.blade.php
@@ -23,7 +23,7 @@
         </div>
 
         {{-- Stats Cards --}}
-        <div class="grid grid-cols-2 lg:grid-cols-5 gap-4 mt-6">
+        <div class="hidden md:grid grid-cols-2 lg:grid-cols-5 gap-4 mt-6">
             @php
                 $stats = app(\App\Services\VesselService::class)->getVesselStats();
             @endphp

--- a/resources/views/livewire/admin/management/vessels/vessel-form.blade.php
+++ b/resources/views/livewire/admin/management/vessels/vessel-form.blade.php
@@ -94,7 +94,7 @@
                                        wire:model.live.debounce.300ms="ownerSearch"
                                        @focus="open = true"
                                        class="form-input w-full {{ $errors->has('owner_client_id') ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : '' }}"
-                                       placeholder="Search for owner...">
+                                       placeholder="Search by name or ID...">
                                 
                                 @if($showOwnerDropdown && count($eligibleOwners) > 0)
                                     <div class="absolute z-10 w-full mt-1 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-y-auto">
@@ -107,7 +107,9 @@
                                                 </div>
                                                 <div>
                                                     <div class="text-sm font-medium">{{ $client['display_name'] }}</div>
-                                                    <div class="text-xs text-muted-foreground">{{ $client['email'] }}</div>
+                                                    @if($client['id_card'])
+                                                        <div class="text-xs text-muted-foreground">ID: {{ $client['id_card'] }}</div>
+                                                    @endif
                                                 </div>
                                             </button>
                                         @endforeach
@@ -131,7 +133,7 @@
                                            wire:model.live.debounce.300ms="renterSearch"
                                            @focus="open = true"
                                            class="form-input flex-1 {{ $errors->has('renter_client_id') ? 'border-red-500 focus:border-red-500 focus:ring-red-500' : '' }}"
-                                           placeholder="Search for renter...">
+                                           placeholder="Search by name or ID...">
                                     @if($renter_client_id)
                                         <button type="button" 
                                                 wire:click="clearRenter"
@@ -152,7 +154,9 @@
                                                 </div>
                                                 <div>
                                                     <div class="text-sm font-medium">{{ $client['display_name'] }}</div>
-                                                    <div class="text-xs text-muted-foreground">{{ $client['email'] }}</div>
+                                                    @if($client['id_card'])
+                                                        <div class="text-xs text-muted-foreground">ID: {{ $client['id_card'] }}</div>
+                                                    @endif
                                                 </div>
                                             </button>
                                         @endforeach

--- a/tests/Unit/VesselServiceTest.php
+++ b/tests/Unit/VesselServiceTest.php
@@ -90,4 +90,18 @@ class VesselServiceTest extends TestCase
             'registration_number' => 'REG-004',
         ]);
     }
+
+    public function test_get_eligible_clients_searches_by_id_card(): void
+    {
+        $client = User::factory()->create([
+            'user_type' => 'client',
+            'is_active' => true,
+            'id_card' => 'ID-12345',
+        ]);
+
+        $service = new VesselService();
+        $results = $service->getEligibleClients('12345');
+
+        $this->assertTrue($results->contains('id', $client->id));
+    }
 }


### PR DESCRIPTION
## Summary
- add vessel config for search limits and owner/renter rule
- allow searching owners or renters by name or ID number
- hide vessel stats on small screens for styling parity

## Testing
- `composer install` *(fails: requires GitHub token)*
- `composer test` *(fails: vendor autoload missing)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1f2814f08332983f926d876632da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Client search now supports name or ID and respects a configurable result limit.
  - ID numbers are shown in owner/renter suggestions; email is no longer displayed.
  - New setting to control whether owner and renter can be the same person.

- Style
  - Vessel stats cards are hidden on small screens; visible from medium screens upward.

- Tests
  - Added unit test covering client search by ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->