### PR TITLE
Stabilize booking wizard step flow and slot creation

### DIFF
--- a/docs/qa/new-reservation-wizard.md
+++ b/docs/qa/new-reservation-wizard.md
@@ -1,0 +1,11 @@
+# New Reservation Wizard QA
+
+## Fixed Issues
+- Step transitions validated server-side via `goToStep` and logged.
+- Booking creation wrapped in a transaction with final availability check.
+- Added unique Livewire keys for dynamic dropdown and slot lists to prevent hydration errors.
+
+## Test Cases
+- Blocked progression to Location step without a selected vessel.
+- Re-attempting to book an occupied slot triggers validation error.
+- Slot selection moves to Services step and preserves choice when navigating back.

--- a/resources/views/livewire/admin/bookings/new-reservation.blade.php
+++ b/resources/views/livewire/admin/bookings/new-reservation.blade.php
@@ -80,7 +80,7 @@
                 @if($bookingType)
                     <div class="step-actions">
                         <div></div> <!-- Spacer -->
-                        <button type="button" class="btn-primary" wire:click="$set('step',2)">
+                        <button type="button" class="btn-primary" wire:click="goToStep(2)" wire:loading.attr="disabled" wire:target="goToStep">
                             Continue with {{ ucfirst($bookingType) }}
                             <x-heroicon name="arrow-right" class="w-4 h-4" />
                         </button>
@@ -116,9 +116,10 @@
                         @if (!empty($clientResults))
                             <div class="search-results">
                                 @foreach ($clientResults as $c)
-                                    <button type="button" 
+                                    <button type="button"
                                             class="search-result-item"
-                                            wire:click="selectClient('{{ $c->id }}')">
+                                            wire:click="selectClient('{{ $c->id }}')"
+                                            wire:key="client-{{ $c->id }}">
                                         <div class="search-result-info">
                                             <span class="search-result-name">{{ $c->name }}</span>
                                             <span class="search-result-email">{{ $c->email }}</span>
@@ -148,9 +149,10 @@
                             @if ($vesselResults && $vesselResults->count())
                                 <div class="search-results">
                                     @foreach ($vesselResults as $v)
-                                        <button type="button" 
+                                        <button type="button"
                                                 class="search-result-item"
-                                                wire:click="selectVessel('{{ $v->id }}')">
+                                                wire:click="selectVessel('{{ $v->id }}')"
+                                                wire:key="vessel-{{ $v->id }}">
                                             <div class="search-result-info">
                                                 <span class="search-result-name">{{ $v->display_name }}</span>
                                             </div>
@@ -171,13 +173,15 @@
                 </div>
                 
                 <div class="step-actions">
-                    <button type="button" class="btn-secondary" wire:click="$set('step',1)">
+                    <button type="button" class="btn-secondary" wire:click="goToStep(1)">
                         <x-heroicon name="arrow-left" class="w-4 h-4" />
                         Back
                     </button>
-                    <button type="button" 
+                    <button type="button"
                             class="btn-primary {{ !$this->selectedVessel ? 'disabled' : '' }}"
-                            wire:click="$set('step',3)"
+                            wire:click="goToStep(3)"
+                            wire:loading.attr="disabled"
+                            wire:target="goToStep"
                             @disabled(!$this->selectedVessel)>
                         Next
                         <x-heroicon name="arrow-right" class="w-4 h-4" />
@@ -232,11 +236,11 @@
                 </div>
                 
                 <div class="step-actions">
-                    <button type="button" class="btn-secondary" wire:click="$set('step',2)">
+                    <button type="button" class="btn-secondary" wire:click="goToStep(2)">
                         <x-heroicon name="arrow-left" class="w-4 h-4" />
                         Back
                     </button>
-                    <button type="button" class="btn-primary" wire:click="$set('step',4)">
+                    <button type="button" class="btn-primary" wire:click="goToStep(4)" wire:loading.attr="disabled" wire:target="goToStep">
                         Next
                         <x-heroicon name="arrow-right" class="w-4 h-4" />
                     </button>
@@ -295,11 +299,11 @@
                 </div>
                 
                 <div class="step-actions">
-                    <button type="button" class="btn-secondary" wire:click="$set('step',3)">
+                    <button type="button" class="btn-secondary" wire:click="goToStep(3)">
                         <x-heroicon name="arrow-left" class="w-4 h-4" />
                         Back
                     </button>
-                    <button type="button" class="btn-primary" wire:click="calculateAvailability">
+                    <button type="button" class="btn-primary" wire:click="calculateAvailability" wire:loading.attr="disabled" wire:target="calculateAvailability">
                         Check Availability
                         <x-heroicon name="magnifying-glass" class="w-4 h-4" />
                     </button>
@@ -321,7 +325,7 @@
                         <x-heroicon name="exclamation-triangle" class="w-12 h-12 text-amber-500 mx-auto mb-4" />
                         <h3>No Available Slots</h3>
                         <p>There are no available slots for the selected timeframe. Please try different dates or times.</p>
-                        <button type="button" class="btn-secondary" wire:click="$set('step',4)">
+                        <button type="button" class="btn-secondary" wire:click="goToStep(4)">
                             Change Date/Time
                         </button>
                     </div>
@@ -330,7 +334,10 @@
                         @foreach ($availableSlots as $slot)
                             <button type="button"
                                     class="slot-card {{ $selectedSlot == $slot->id ? 'selected' : '' }}"
-                                    wire:click="$set('selectedSlot','{{ $slot->id }}'); $set('step',6)">
+                                    wire:key="slot-{{ $slot->id }}"
+                                    wire:click="selectSlot({{ $slot->id }})"
+                                    wire:loading.attr="disabled"
+                                    wire:target="selectSlot">
                                 <div class="slot-info">
                                     <h4>{{ $slot->code }}</h4>
                                     <div class="slot-location">
@@ -348,7 +355,7 @@
                 @endif
                 
                 <div class="step-actions">
-                    <button type="button" class="btn-secondary" wire:click="$set('step',4)">
+                    <button type="button" class="btn-secondary" wire:click="goToStep(4)">
                         <x-heroicon name="arrow-left" class="w-4 h-4" />
                         Back
                     </button>
@@ -367,7 +374,7 @@
                 
                 <div class="services-section">
                     @foreach ($this->servicesList as $code => $label)
-                        <label class="service-item">
+                        <label class="service-item" wire:key="service-{{ $code }}">
                             <input type="checkbox" wire:model="selectedServices" value="{{ $code }}" class="service-checkbox">
                             <div class="service-info">
                                 <h4>{{ $label }}</h4>
@@ -381,11 +388,11 @@
                 </div>
                 
                 <div class="step-actions">
-                    <button type="button" class="btn-secondary" wire:click="$set('step',5)">
+                    <button type="button" class="btn-secondary" wire:click="goToStep(5)">
                         <x-heroicon name="arrow-left" class="w-4 h-4" />
                         Back
                     </button>
-                    <button type="button" class="btn-success" wire:click="createBooking">
+                    <button type="button" class="btn-success" wire:click="createBooking" wire:loading.attr="disabled" wire:target="createBooking">
                         <x-heroicon name="check-circle" class="w-5 h-5" />
                         Create Booking
                     </button>


### PR DESCRIPTION
## Summary
- Centralize step navigation with server-side `goToStep` and slot selection helpers
- Log dropdown searches and availability queries
- Wrap booking creation in transaction with final availability check
- Add unique Livewire keys and QA notes

## Testing
- `composer test` *(fails: require(/workspace/nautica-v2/vendor/autoload.php): No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab21e44ae4833285169ad7bfe5c510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Prefills start/end date and time with sensible defaults.
  - Adds clear loading indicators during navigation, availability checks, and booking creation.

- Improvements
  - Centralized, validated step navigation to prevent invalid progress.
  - More reliable slot selection with preserved choice when navigating back.
  - Smoother dynamic lists to reduce flicker and instability.

- Bug Fixes
  - Prevents double-booking with robust server-side checks and user-friendly errors.

- Documentation
  - Added QA guide for the New Reservation Wizard with test cases and verified behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->